### PR TITLE
Fix travis

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -10,4 +10,7 @@
     version: 26compat
 - git:
     local-name: robosherlock
-    uri: https://github.com/RoboSherlock/robosherlock.git
+    uri: https://github.com/Surxz/robosherlock.git
+- git:
+    local-name: geometry2
+    uri: https://github.com/ros/geometry2.git

--- a/percepteros/package.xml
+++ b/percepteros/package.xml
@@ -44,6 +44,7 @@
   <depend>tf_conversions</depend>
   <depend>image_transport</depend>
   <depend>image_geometry</depend>
+  <depend>tf2_geometry_msgs</depend>
   <!-- install dependencies for robosherlock -->
   <depend>automake</depend>
   <depend>xerces</depend>


### PR DESCRIPTION
Das hier sollte zumindest schon mal einen Teil der Dependency Probleme von Travis lösen.
Es wird jetzt das geometry2 metapackage gezogen und ich habe tf2_geometry_msgs zur package.xml von perceptoros hinzugefügt, damit der das auch in der richtigen Reihenfolge baut.

Und ich hab die Source für robosherlock auf den Fork von Constantin gesetzt, da ihr den ja benutzt, wenn ich das richtig verstehe.